### PR TITLE
Pin requests dependencies and require bzlmod

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,3 @@
+# Agent Instructions
+
+This repository requires Bazel's bzlmod (MODULE.bazel). All builds and dependency changes must use Bazel modules; do not rely on the legacy WORKSPACE mechanism.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
+certifi==2025.8.3
+charset-normalizer==3.4.3
+idna==3.10
+urllib3==2.5.0
 requests==2.31.0


### PR DESCRIPTION
## Summary
- include transitive Python deps (certifi, charset-normalizer, idna, urllib3) so Bazel resolves `requests`
- document that this repo uses Bazel modules and requires bzlmod

## Testing
- `bazel run //:hello` *(fails: certificate_unknown: unable to find valid certification path to requested target)*

------
https://chatgpt.com/codex/tasks/task_e_68b06e275c048325ba7efa0c5c5fa9fe