### PR TITLE
chore: expose virtualenv rule at repo root

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_python//python:py_binary.bzl", "py_binary")
+
+py_binary(
+    name = "setup_venv",
+    srcs = ["python/setup_venv.py"],
+    main = "python/setup_venv.py",
+    data = ["python/requirements.txt"],
+)
+

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To create a virtual environment in the repo root that matches the Bazel Python
 toolchain and installs `requirements.txt` (including `ipython` and `pgcli`):
 
 ```bash
-bazel run //python:setup_venv
+bazel run //:setup_venv
 ```
 
 The environment is created at `.venv/` and is ignored by Git.

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -7,10 +7,3 @@ py_binary(
     main = "hello.py",
     deps = [requirement("requests")],
 )
-
-py_binary(
-    name = "setup_venv",
-    srcs = ["setup_venv.py"],
-    main = "setup_venv.py",
-    data = ["requirements.txt"],
-)


### PR DESCRIPTION
## Summary
- expose `setup_venv` py_binary at repository root
- drop per-package venv rule
- document running `bazel run //:setup_venv`

## Testing
- `bazel build //:setup_venv //python:hello` *(fails: certificate_unknown, unable to find valid certification path to requested target)*

------
https://chatgpt.com/codex/tasks/task_e_68b07768b1708325b634a1658e05e44c