### PR TITLE
Fix setup_venv bazel target

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,9 +1,4 @@
-load("@rules_python//python:py_binary.bzl", "py_binary")
-
-py_binary(
+alias(
     name = "setup_venv",
-    srcs = ["python/setup_venv.py"],
-    main = "python/setup_venv.py",
-    data = ["python/requirements.txt"],
+    actual = "//python:setup_venv",
 )
-

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -7,3 +7,10 @@ py_binary(
     main = "hello.py",
     deps = [requirement("requests")],
 )
+
+py_binary(
+    name = "setup_venv",
+    srcs = ["setup_venv.py"],
+    main = "setup_venv.py",
+    data = ["requirements.txt"],
+)


### PR DESCRIPTION
## Summary
- Define `setup_venv` py_binary in `python/` package
- Expose `setup_venv` at repo root via alias

## Testing
- `bazel run //:setup_venv` *(fails: Error computing the main repository mapping: Failed to fetch registry due to certificate_unknown)*

------
https://chatgpt.com/codex/tasks/task_e_68b07f6841cc8325b21a5bf0577242e0