### PR TITLE
Fix setup_venv alias visibility

### DIFF
--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -13,4 +13,5 @@ py_binary(
     srcs = ["setup_venv.py"],
     main = "setup_venv.py",
     data = ["requirements.txt"],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
## Summary
- expose `python:setup_venv` publicly so the root alias can run it

## Testing
- `bazel run //:setup_venv` *(fails: command interrupted while computing main repo mapping)*

------
https://chatgpt.com/codex/tasks/task_e_68b082a4b9508325bab82aad9d3002b1