### PR TITLE
docs: add troubleshooting for SSL certificate errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,15 @@ source scripts/export_env.sh
 The script exports the variables defined in `.env` into the current shell for
 tools like `pgcli`.
 
+## Troubleshooting
+
+If you encounter SSL certificate chain errors:
+
+* Update the operating system's CA certificates (for example, `sudo update-ca-certificates` on Debian/Ubuntu).
+* Force Bazel to use its bundled JDK: `bazel --host_jvm_args=-Djavax.net.ssl.trustStore=<path>` or install Bazelisk, which ships its own JDK.
+
+The repository's `.bazelversion` already specifies a current Bazel release, minimizing such issues.
+
 ## Usage
 
 Run Bazel commands from the repository root. For example:


### PR DESCRIPTION
## Summary
- add troubleshooting section to README with guidance on resolving SSL certificate chain issues
- note that `.bazelversion` pins a current Bazel release to reduce certificate problems

## Testing
- `bazel test //...` *(fails: certificate_unknown)*

------
https://chatgpt.com/codex/tasks/task_e_68b0864a4e08832595bbf7dce0d891cf