### PR TITLE
docs: clarify Bazelisk usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,3 +6,5 @@ changes must use Bazel modules; do not rely on the legacy WORKSPACE mechanism.
 Python sources live under the `python/` directory. Environment variables for local
 development should be stored in `.env` (ignored by Git) and loaded with
 `source scripts/export_env.sh`.
+
+All Bazel commands must be executed through Bazelisk to honor `.bazelversion`.

--- a/README.md
+++ b/README.md
@@ -41,11 +41,18 @@ The repository's `.bazelversion` already specifies a current Bazel release, mini
 
 ## Usage
 
-Run Bazel commands from the repository root. For example:
+Run Bazel commands from the repository root using Bazelisk so the version in
+`.bazelversion` is honored. For example:
 
 ```bash
 bazel build //python:hello
 bazel run //python:hello
+```
+
+If `bazel` isn't provided by Bazelisk on your PATH, run Bazelisk directly:
+
+```bash
+bazelisk run //python:hello
 ```
 
 To create a virtual environment in the repo root that matches the Bazel Python


### PR DESCRIPTION
## Summary
- note in AGENTS to run Bazel via Bazelisk respecting `.bazelversion`
- expand README usage section to reinforce Bazelisk usage and show explicit `bazelisk` example

## Testing
- `bazel test //...` *(fails: unable to find valid certification path)*

------
https://chatgpt.com/codex/tasks/task_e_68b086eee1cc8325a89b9a90970f4efb