### PR TITLE
Add pgcli helper script and documentation

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,5 +1,5 @@
 PG_HOST=localhost
 PG_PORT=5432
-PG_USER=postgres
-PG_PASS=postgres
-DB_NAME=app
+PG_USER=myuser
+PG_PASS=mypass
+DB_NAME=mydb

--- a/README.md
+++ b/README.md
@@ -30,6 +30,23 @@ source scripts/export_env.sh
 The script exports the variables defined in `.env` into the current shell for
 tools like `pgcli`.
 
+The following variables define how to connect to PostgreSQL:
+
+- `PG_HOST` - database host
+- `PG_PORT` - database port
+- `PG_USER` - database user
+- `PG_PASS` - database password
+- `DB_NAME` - database name
+
+## Connect with pgcli
+
+```bash
+cp .env-sample .env
+source scripts/export_env.sh
+bazel run //:setup_venv
+bazel run //scripts:pgcli
+```
+
 ## Troubleshooting
 
 If you encounter SSL certificate chain errors:

--- a/scripts/BUILD.bazel
+++ b/scripts/BUILD.bazel
@@ -1,0 +1,5 @@
+sh_binary(
+    name = "pgcli",
+    srcs = ["pgcli.sh"],
+    visibility = ["//visibility:public"],
+)

--- a/scripts/pgcli.sh
+++ b/scripts/pgcli.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Run pgcli using credentials from .env
+
+set -euo pipefail
+
+# Determine repository root
+ROOT="${BUILD_WORKSPACE_DIRECTORY:-$(dirname "$0")/..}"
+
+ENV_FILE="$ROOT/.env"
+CLI="$ROOT/.venv/bin/pgcli"
+
+if [ -f "$ENV_FILE" ]; then
+  # shellcheck disable=SC1091
+  source "$ENV_FILE"
+else
+  echo ".env file not found" >&2
+  exit 1
+fi
+
+PGPASSWORD="$PG_PASS" "$CLI" -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" "$DB_NAME"


### PR DESCRIPTION
## Summary
- add `scripts/pgcli.sh` to run pgcli using `.env` configuration
- expose pgcli via Bazel target
- document PostgreSQL env vars and pgcli usage

## Testing
- `bazel test //...` *(fails: certificate_unknown - unable to find valid certification path)*

------
https://chatgpt.com/codex/tasks/task_e_68b089d107cc8325a23d3bdff737a1b1