### PR TITLE
Add Gmail poller utility

### DIFF
--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@pypi//:requirements.bzl", "requirement")
 load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_python//python:py_library.bzl", "py_library")
 
 py_binary(
     name = "hello",
@@ -19,5 +20,16 @@ py_binary(
     srcs = ["setup_venv.py"],
     main = "setup_venv.py",
     data = ["requirements.txt"],
+    visibility = ["//visibility:public"],
+)
+
+py_library(
+    name = "gmail_poller",
+    srcs = ["gmail_poller.py"],
+    deps = [
+        requirement("google-api-python-client"),
+        requirement("google-auth"),
+        requirement("google-auth-oauthlib"),
+    ],
     visibility = ["//visibility:public"],
 )

--- a/python/gmail_poller.py
+++ b/python/gmail_poller.py
@@ -1,0 +1,63 @@
+"""Utilities for polling Gmail for new messages."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List
+
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+
+TOKEN_PATH = Path("token.json")
+SCOPES = ["https://www.googleapis.com/auth/gmail.modify"]
+
+
+@dataclass
+class Email:
+    """Simple representation of an email message."""
+
+    id: str
+    snippet: str
+
+
+class GmailPoller:
+    """Polls the Gmail API for messages from a specific sender."""
+
+    def __init__(self) -> None:
+        self.service = self._authorize()
+
+    def _authorize(self):
+        creds: Credentials | None = None
+        if TOKEN_PATH.exists():
+            creds = Credentials.from_authorized_user_file(str(TOKEN_PATH), SCOPES)
+        if not creds or not creds.valid:
+            if creds and creds.expired and creds.refresh_token:
+                creds.refresh(Request())
+            else:
+                flow = InstalledAppFlow.from_client_secrets_file("credentials.json", SCOPES)
+                creds = flow.run_local_server(port=0)
+            TOKEN_PATH.write_text(creds.to_json())
+        return build("gmail", "v1", credentials=creds)
+
+    def poll(self, sender: str) -> List[Email]:
+        """Return unread messages from the given sender.
+
+        Messages are marked as read so they are not returned again.
+        """
+        result = (
+            self.service.users()
+            .messages()
+            .list(userId="me", q=f"from:{sender} is:unread")
+            .execute()
+        )
+        messages = result.get("messages", [])
+        emails: List[Email] = []
+        for msg in messages:
+            full = self.service.users().messages().get(userId="me", id=msg["id"]).execute()
+            emails.append(Email(id=full["id"], snippet=full.get("snippet", "")))
+            self.service.users().messages().modify(
+                userId="me", id=full["id"], body={"removeLabelIds": ["UNREAD"]}
+            ).execute()
+        return emails


### PR DESCRIPTION
## Summary
- add GmailPoller class to fetch unread messages from specific sender
- expose poll method and module-level constants for token path and scopes
- register gmail_poller library in Bazel BUILD file

## Testing
- `python -m py_compile python/gmail_poller.py`
- `bazelisk build //python:gmail_poller` *(fails: certificate_unknown PKIX path building failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0b52ed348325a15ef1251aa77d37