### PR TITLE
Add Gmail polling agent binary

### DIFF
--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -33,3 +33,13 @@ py_library(
     ],
     visibility = ["//visibility:public"],
 )
+
+py_binary(
+    name = "poll_gmail_agent",
+    srcs = ["poll_gmail_agent.py"],
+    main = "poll_gmail_agent.py",
+    deps = [
+        ":gmail_poller",
+        requirement("semantic-kernel"),
+    ],
+)

--- a/python/poll_gmail_agent.py
+++ b/python/poll_gmail_agent.py
@@ -1,0 +1,29 @@
+import logging
+import os
+import time
+
+import semantic_kernel as sk
+
+from gmail_poller import GmailPoller
+
+
+def main() -> None:
+    """Poll Gmail for new messages and log them."""
+    logging.basicConfig(level=logging.INFO)
+
+    kernel = sk.Kernel()
+    poller = GmailPoller()
+
+    # Register a skill/function that calls `GmailPoller.poll`.
+    kernel.add_native_function("gmail", "poll", poller.poll)
+
+    sender = os.environ.get("GMAIL_SENDER", "")
+    while True:
+        emails = kernel.invoke("gmail", "poll", sender)
+        for email in emails:
+            logging.info("New email %s: %s", email.id, email.snippet)
+        time.sleep(60)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement `poll_gmail_agent.py` that uses Semantic Kernel to poll Gmail and log new messages
- expose new `poll_gmail_agent` Bazel target

## Testing
- `python -m py_compile python/poll_gmail_agent.py`
- `bazel build //python:poll_gmail_agent` *(fails: PKIX path building failed: unable to find valid certification path to requested target)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0d29bb688325ad952cf8d4dd261b