### PR TITLE
feat: add Gmail env vars

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -3,3 +3,7 @@ PG_PORT=5432
 PG_USER=myuser
 PG_PASS=mypass
 DB_NAME=mydb
+GMAIL_CLIENT_ID=your-client-id
+GMAIL_CLIENT_SECRET=your-client-secret
+GMAIL_TOKEN_PATH=token.json
+GMAIL_SENDER_FILTER=example@example.com

--- a/scripts/export_env.sh
+++ b/scripts/export_env.sh
@@ -7,6 +7,7 @@ if [ -f "$(dirname "$0")/../.env" ]; then
   # shellcheck disable=SC1091
   source "$(dirname "$0")/../.env"
   set +a
+  export GMAIL_CLIENT_ID GMAIL_CLIENT_SECRET GMAIL_TOKEN_PATH GMAIL_SENDER_FILTER
   echo "Environment variables loaded from .env"
 else
   echo ".env file not found" >&2


### PR DESCRIPTION
## Summary
- add Gmail OAuth credentials and sender filter to sample env file
- export Gmail variables in environment loader script

## Testing
- `bash -n scripts/export_env.sh`
- `shellcheck scripts/export_env.sh` *(info: Command appears to be unreachable. Check usage (or ignore if invoked indirectly))*
- `bazel test //...` *(certificate_unknown: unable to find valid certification path to requested target)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0f51abd88325a4fc1f08065782da