### PR TITLE
Add Gmail poller unit test

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,3 +2,8 @@ alias(
     name = "setup_venv",
     actual = "//python:setup_venv",
 )
+
+test_suite(
+    name = "tests",
+    tests = ["//python:tests"],
+)

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -43,3 +43,13 @@ py_binary(
         requirement("semantic-kernel"),
     ],
 )
+
+py_test(
+    name = "gmail_poller_test",
+    srcs = ["test_gmail_poller.py"],
+    deps = [":gmail_poller"],
+)
+
+test_suite(
+    name = "tests",
+)

--- a/python/test_gmail_poller.py
+++ b/python/test_gmail_poller.py
@@ -1,0 +1,53 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from gmail_poller import Email, GmailPoller
+
+
+class GmailPollerTest(TestCase):
+    def setUp(self) -> None:
+        self.service = MagicMock()
+        users = self.service.users.return_value
+        self.messages = users.messages.return_value
+
+        # Simulate two unread messages
+        self.messages.list.return_value.execute.return_value = {
+            "messages": [{"id": "1"}, {"id": "2"}]
+        }
+
+        def get_call(userId: str, id: str):  # noqa: D401 - short mock function
+            msg = MagicMock()
+            msg.execute.return_value = {
+                "id": id,
+                "snippet": f"snippet {id}",
+            }
+            return msg
+
+        self.messages.get.side_effect = get_call
+
+        def modify_call(userId: str, id: str, body: dict):
+            mod = MagicMock()
+            mod.execute.return_value = None
+            return mod
+
+        self.messages.modify.side_effect = modify_call
+
+    def test_poll_returns_emails(self) -> None:
+        with patch.object(GmailPoller, "_authorize", return_value=self.service):
+            poller = GmailPoller()
+            emails = poller.poll("sender@example.com")
+
+        self.assertEqual(
+            [
+                Email(id="1", snippet="snippet 1"),
+                Email(id="2", snippet="snippet 2"),
+            ],
+            emails,
+        )
+        self.assertEqual(2, self.messages.modify.call_count)
+        self.messages.modify.assert_any_call(
+            userId="me", id="1", body={"removeLabelIds": ["UNREAD"]}
+        )
+        self.messages.modify.assert_any_call(
+            userId="me", id="2", body={"removeLabelIds": ["UNREAD"]}
+        )


### PR DESCRIPTION
## Summary
- add unittest-based tests for GmailPoller using mocked Gmail API
- declare Bazel py_test target for GmailPoller
- aggregate tests via a top-level Bazel test suite

## Testing
- `bazel test //...` *(fails: unable to find valid certification path to requested target)*

------
https://chatgpt.com/codex/tasks/task_e_68bb14b1a7fc83259e6eadfb8448b0a3