### PR TITLE
Add script to generate Gmail OAuth token

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,16 +92,18 @@ Semantic Kernel agent that logs unread messages from a sender.
    bazel run //:setup_venv
    ```
 
-2. Create a `.env` with your Gmail OAuth client and desired sender filter:
+2. Create a `.env` with your Gmail OAuth client and desired sender filter, then
+   generate an OAuth token:
 
    ```bash
    cp .env-sample .env
    # edit GMAIL_CLIENT_ID, GMAIL_CLIENT_SECRET, GMAIL_SENDER
    source scripts/export_env.sh
+   python get_gmail_token.py --secrets client_secret.json --token token.json
    ```
 
-   The first run will launch a browser for OAuth consent and store a token at
-   `GMAIL_TOKEN_PATH` (default `token.json`).
+   The script launches a browser for OAuth consent and writes the token to
+   `token.json`.
 
 3. Start the poller:
 

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -44,6 +44,16 @@ py_binary(
     ],
 )
 
+py_binary(
+    name = "get_gmail_token",
+    srcs = ["get_gmail_token.py"],
+    main = "get_gmail_token.py",
+    deps = [
+        requirement("google-auth"),
+        requirement("google-auth-oauthlib"),
+    ],
+)
+
 py_test(
     name = "gmail_poller_test",
     srcs = ["test_gmail_poller.py"],

--- a/python/get_gmail_token.py
+++ b/python/get_gmail_token.py
@@ -1,0 +1,38 @@
+"""Script to obtain a Gmail API token.
+
+Usage:
+    python get_gmail_token.py --secrets client_secret.json --token token.json
+"""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from google_auth_oauthlib.flow import InstalledAppFlow
+
+SCOPES = ["https://www.googleapis.com/auth/gmail.modify"]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate a Gmail OAuth token")
+    parser.add_argument(
+        "--secrets",
+        type=Path,
+        required=True,
+        help="Path to client secrets JSON",
+    )
+    parser.add_argument(
+        "--token",
+        type=Path,
+        default=Path("token.json"),
+        help="Path to write the OAuth token",
+    )
+    args = parser.parse_args()
+
+    flow = InstalledAppFlow.from_client_secrets_file(str(args.secrets), SCOPES)
+    creds = flow.run_local_server(port=0)
+    args.token.write_text(creds.to_json())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `get_gmail_token.py` to fetch and store Gmail API credentials
- expose script via Bazel target
- document token generation command

## Testing
- `bazel test //python:tests` *(fails: Error accessing registry https://bcr.bazel.build/: certificate_unknown)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1a952fb883258c9e66c29aacaa7d