### PR TITLE
Expose Gmail poller through chat agent

### DIFF
--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -45,6 +45,16 @@ py_binary(
 )
 
 py_binary(
+    name = "chat_gmail_agent",
+    srcs = ["chat_gmail_agent.py"],
+    main = "chat_gmail_agent.py",
+    deps = [
+        ":gmail_poller",
+        requirement("semantic-kernel"),
+    ],
+)
+
+py_binary(
     name = "get_gmail_token",
     srcs = ["get_gmail_token.py"],
     main = "get_gmail_token.py",

--- a/python/chat_gmail_agent.py
+++ b/python/chat_gmail_agent.py
@@ -1,0 +1,62 @@
+"""Interactive chat agent that can poll Gmail using Semantic Kernel."""
+import asyncio
+import logging
+import os
+import semantic_kernel as sk
+from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
+from gmail_poller import GmailPoller
+
+
+def create_kernel() -> sk.Kernel:
+    """Create and configure the Semantic Kernel."""
+    kernel = sk.Kernel()
+
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if api_key:
+        service = OpenAIChatCompletion(ai_model_id="gpt-4o-mini", api_key=api_key)
+        kernel.add_service(service)
+    else:
+        logging.warning("OPENAI_API_KEY is not set; chat will fail")
+
+    poller = GmailPoller()
+    kernel.add_function(
+        plugin_name="gmail",
+        function=poller.poll,
+        function_name="poll",
+        description="Poll Gmail for unread messages from a sender.",
+    )
+    return kernel
+
+
+async def chat_loop(kernel: sk.Kernel) -> None:
+    """Simple interactive chat loop."""
+    print("Type 'exit' to quit.")
+    while True:
+        user = input("User > ")
+        if user.strip().lower() in {"exit", "quit"}:
+            break
+        # Forward user message through the kernel so the model can decide to call functions.
+        result = await kernel.invoke(
+            plugin_name="chat",
+            function_name="chat",
+            input=user,
+        )
+        if result:
+            print(result)
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    kernel = create_kernel()
+    # Register a basic chat function that relays messages to the model.
+    kernel.add_function(
+        plugin_name="chat",
+        function_name="chat",
+        description="General chat interface",
+        prompt="""{{$input}}""",
+    )
+    asyncio.run(chat_loop(kernel))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/poll_gmail_agent.py
+++ b/python/poll_gmail_agent.py
@@ -1,13 +1,13 @@
+import asyncio
 import logging
 import os
-import time
 
 import semantic_kernel as sk
 
 from gmail_poller import GmailPoller
 
 
-def main() -> None:
+async def main() -> None:
     """Poll Gmail for new messages and log them."""
     logging.basicConfig(level=logging.INFO)
 
@@ -15,15 +15,15 @@ def main() -> None:
     poller = GmailPoller()
 
     # Register a skill/function that calls `GmailPoller.poll`.
-    kernel.add_native_function("gmail", "poll", poller.poll)
+    kernel.add_function("gmail", poller.poll, function_name="poll")
 
     sender = os.environ.get("GMAIL_SENDER", "")
     while True:
-        emails = kernel.invoke("gmail", "poll", sender)
+        emails = await kernel.invoke("gmail", "poll", sender=sender)
         for email in emails:
             logging.info("New email %s: %s", email.id, email.snippet)
-        time.sleep(60)
+        await asyncio.sleep(60)
 
 
 if __name__ == "__main__":
-    main()
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- register `GmailPoller.poll` as native function in kernel setup
- add interactive chat agent that forwards messages through the kernel so the LLM can invoke `poll`
- update Gmail polling script to use async `kernel.invoke`

## Testing
- `bazelisk test //python:tests` *(fails: certificate_unknown)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1c5938fc8325b712d04cd5d04506