### PR TITLE
Fix gmail poller import path in Bazel build

### DIFF
--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -26,6 +26,7 @@ py_binary(
 py_library(
     name = "gmail_poller",
     srcs = ["gmail_poller.py"],
+    imports = ["."],
     deps = [
         requirement("google-api-python-client"),
         requirement("google-auth"),


### PR DESCRIPTION
## Summary
- ensure gmail_poller library exports its directory on PYTHONPATH so poll_gmail_agent can import it

## Testing
- `bazel test //python:gmail_poller_test` *(fails: Error accessing registry https://bcr.bazel.build/ ... certificate_unknown)*

------
https://chatgpt.com/codex/tasks/task_e_68bb2e6f17a483258acffc1581fd67cf