### PR TITLE
Ensure Gmail credentials accessible from Bazel targets

### DIFF
--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -2,6 +2,11 @@ load("@pypi//:requirements.bzl", "requirement")
 load("@rules_python//python:py_binary.bzl", "py_binary")
 load("@rules_python//python:py_library.bzl", "py_library")
 
+filegroup(
+    name = "gmail_credentials",
+    srcs = ["credentials.json"],
+)
+
 py_binary(
     name = "hello",
     srcs = ["hello.py"],
@@ -43,6 +48,7 @@ py_binary(
         ":gmail_poller",
         requirement("semantic-kernel"),
     ],
+    data = [":gmail_credentials"],
 )
 
 py_binary(
@@ -53,6 +59,7 @@ py_binary(
         ":gmail_poller",
         requirement("semantic-kernel"),
     ],
+    data = [":gmail_credentials"],
 )
 
 py_binary(
@@ -63,6 +70,7 @@ py_binary(
         requirement("google-auth"),
         requirement("google-auth-oauthlib"),
     ],
+    data = [":gmail_credentials"],
 )
 
 py_test(

--- a/python/credentials.json
+++ b/python/credentials.json
@@ -1,0 +1,7 @@
+{
+  "installed": {
+    "client_id": "your-client-id",
+    "client_secret": "your-client-secret",
+    "redirect_uris": ["http://localhost"]
+  }
+}

--- a/python/gmail_poller.py
+++ b/python/gmail_poller.py
@@ -1,6 +1,7 @@
 """Utilities for polling Gmail for new messages."""
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import List
@@ -10,7 +11,12 @@ from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 
-TOKEN_PATH = Path("token.json")
+TOKEN_PATH = Path(os.environ.get("GMAIL_TOKEN_PATH", "token.json"))
+CREDENTIALS_PATH = Path(
+    os.environ.get(
+        "GMAIL_CREDENTIALS_FILE", str(Path(__file__).with_name("credentials.json"))
+    )
+)
 SCOPES = ["https://www.googleapis.com/auth/gmail.modify"]
 
 
@@ -36,7 +42,9 @@ class GmailPoller:
             if creds and creds.expired and creds.refresh_token:
                 creds.refresh(Request())
             else:
-                flow = InstalledAppFlow.from_client_secrets_file("credentials.json", SCOPES)
+                flow = InstalledAppFlow.from_client_secrets_file(
+                    str(CREDENTIALS_PATH), SCOPES
+                )
                 creds = flow.run_local_server(port=0)
             TOKEN_PATH.write_text(creds.to_json())
         return build("gmail", "v1", credentials=creds)


### PR DESCRIPTION
## Summary
- add sample Gmail OAuth credentials and expose via Bazel filegroup
- allow GmailPoller to read credential/token paths from env vars and bundle creds in binaries

## Testing
- `bazelisk test //python:tests` *(fails: Error accessing registry https://bcr.bazel.build/: certificate_unknown)*
- `PYTHONPATH=python python -m unittest python/test_gmail_poller.py`
- `PYTHONPATH=python python python/poll_gmail_agent.py` *(fails: ValueError: Client secrets is not in the correct format.)*

------
https://chatgpt.com/codex/tasks/task_e_68bb301b6728832593ff1338c6ddd500