### PR TITLE
Fix Semantic Kernel invoke usage

### DIFF
--- a/python/poll_gmail_agent.py
+++ b/python/poll_gmail_agent.py
@@ -15,12 +15,16 @@ async def main() -> None:
     poller = GmailPoller()
 
     # Register a skill/function that calls `GmailPoller.poll`.
-    kernel.add_function("gmail", poller.poll, function_name="poll")
+    kernel.add_function(
+        plugin_name="gmail", function=poller.poll, function_name="poll"
+    )
 
     sender = os.environ.get("GMAIL_SENDER", "")
     while True:
-        emails = await kernel.invoke("gmail", "poll", sender=sender)
-        for email in emails:
+        result = await kernel.invoke(
+            function_name="poll", plugin_name="gmail", sender=sender
+        )
+        for email in result.value if result else []:
             logging.info("New email %s: %s", email.id, email.snippet)
         await asyncio.sleep(60)
 

--- a/python/test_gmail_poller.py
+++ b/python/test_gmail_poller.py
@@ -59,10 +59,17 @@ class GmailPollerTest(TestCase):
         with patch.object(GmailPoller, "_authorize", return_value=self.service):
             poller = GmailPoller()
             kernel = sk.Kernel()
-            kernel.add_function("gmail", poller.poll, function_name="poll")
-            emails = asyncio.run(
-                kernel.invoke("gmail", "poll", sender="sender@example.com")
+            kernel.add_function(
+                plugin_name="gmail", function=poller.poll, function_name="poll"
             )
+            result = asyncio.run(
+                kernel.invoke(
+                    function_name="poll",
+                    plugin_name="gmail",
+                    sender="sender@example.com",
+                )
+            )
+            emails = result.value if result else []
 
         self.assertEqual(
             [


### PR DESCRIPTION
## Summary
- update poll_gmail_agent to use keyword-based Semantic Kernel invocation and extract result value
- adjust unit test to match new Semantic Kernel API

## Testing
- `PYTHONPATH=python python -m unittest python.test_gmail_poller`
- `bazel test //python:gmail_poller_test` *(fails: certificate_unknown: unable to find valid certification path to requested target)*

------
https://chatgpt.com/codex/tasks/task_e_68bb343df1b8832581a72c258ca6c693