### PR TITLE
Handle chat model errors gracefully

### DIFF
--- a/python/chat_gmail_agent.py
+++ b/python/chat_gmail_agent.py
@@ -4,6 +4,7 @@ import logging
 import os
 import semantic_kernel as sk
 from semantic_kernel.connectors.ai.open_ai import OpenAIChatCompletion
+from semantic_kernel.exceptions import KernelInvokeException
 from gmail_poller import GmailPoller
 
 
@@ -36,11 +37,17 @@ async def chat_loop(kernel: sk.Kernel) -> None:
         if user.strip().lower() in {"exit", "quit"}:
             break
         # Forward user message through the kernel so the model can decide to call functions.
-        result = await kernel.invoke(
-            plugin_name="chat",
-            function_name="chat",
-            input=user,
-        )
+        try:
+            result = await kernel.invoke(
+                plugin_name="chat",
+                function_name="chat",
+                input=user,
+            )
+        except KernelInvokeException as exc:
+            logging.error("Chat invocation failed: %s", exc)
+            print("Error: unable to generate chat response. Check API key and quota.")
+            continue
+
         if result:
             print(result)
 


### PR DESCRIPTION
## Summary
- Catch KernelInvokeException in chat loop
- Warn user when chat model fails (likely due to missing API key or quota)

## Testing
- `bazel test //python:tests` *(fails: certificate_unknown PKIX path building failed)*
- `bazel run //python:chat_gmail_agent` *(fails: certificate_unknown PKIX path building failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb36f3d7cc83259318bcc6897a4894