### PR TITLE
Fix semantic-kernel settings parameter

### DIFF
--- a/python/chat_gmail_agent.py
+++ b/python/chat_gmail_agent.py
@@ -45,7 +45,7 @@ async def chat_loop(kernel: sk.Kernel) -> None:
                 plugin_name="chat",
                 function_name="chat",
                 input=user,
-                execution_settings=OpenAIChatPromptExecutionSettings(
+                settings=OpenAIChatPromptExecutionSettings(
                     tool_choice="auto"
                 ),
             )


### PR DESCRIPTION
## Summary
- Fix chat Gmail agent to use the `settings` parameter when invoking the kernel with `OpenAIChatPromptExecutionSettings`

## Testing
- `bazel test //python:tests` *(fails: Error computing the main repository mapping: Error accessing registry https://bcr.bazel.build/)*
- `bazel run //python:chat_gmail_agent` *(fails: Error computing the main repository mapping: Error accessing registry https://bcr.bazel.build/)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4508de148325919b9f7c0ddd7ffd