### PR TITLE
Remove unsupported tool choice

### DIFF
--- a/python/chat_gmail_agent.py
+++ b/python/chat_gmail_agent.py
@@ -45,9 +45,6 @@ async def chat_loop(kernel: sk.Kernel) -> None:
                 plugin_name="chat",
                 function_name="chat",
                 input=user,
-                settings=OpenAIChatPromptExecutionSettings(
-                    tool_choice="auto"
-                ),
             )
         except KernelInvokeException as exc:
             logging.error("Chat invocation failed: %s", exc)


### PR DESCRIPTION
## Summary
- fix chat agent invocation by removing manual `tool_choice` parameter

## Testing
- `bazel test //python:test_gmail_poller` *(fails: certificate_unknown PKIX path building failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb461ec0888325beb0da2609fe08bc