### PR TITLE
Enable tool use in chat Gmail agent

### DIFF
--- a/python/chat_gmail_agent.py
+++ b/python/chat_gmail_agent.py
@@ -41,10 +41,12 @@ async def chat_loop(kernel: sk.Kernel) -> None:
             break
         # Forward user message through the kernel so the model can decide to call functions.
         try:
+            settings = OpenAIChatPromptExecutionSettings(tool_choice="auto")
             result = await kernel.invoke(
                 plugin_name="chat",
                 function_name="chat",
                 input=user,
+                execution_settings=settings,
             )
         except KernelInvokeException as exc:
             logging.error("Chat invocation failed: %s", exc)


### PR DESCRIPTION
## Summary
- ensure chat agent exposes registered tools to OpenAI by invoking with `OpenAIChatPromptExecutionSettings(tool_choice="auto")`

## Testing
- `bazel test //python:test_gmail_poller` *(fails: certificate_unknown PKIX path building failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb479540cc8325978f93fb4941721f