### PR TITLE
Use KernelArguments for execution settings in Gmail chat agent

### DIFF
--- a/python/chat_gmail_agent.py
+++ b/python/chat_gmail_agent.py
@@ -7,6 +7,7 @@ from semantic_kernel.connectors.ai.open_ai import (
     OpenAIChatCompletion,
     OpenAIChatPromptExecutionSettings,
 )
+from semantic_kernel.functions.kernel_arguments import KernelArguments
 from semantic_kernel.exceptions import KernelInvokeException
 from gmail_poller import GmailPoller
 
@@ -46,7 +47,7 @@ async def chat_loop(kernel: sk.Kernel) -> None:
                 plugin_name="chat",
                 function_name="chat",
                 input=user,
-                execution_settings=settings,
+                arguments=KernelArguments(settings=settings),
             )
         except KernelInvokeException as exc:
             logging.error("Chat invocation failed: %s", exc)


### PR DESCRIPTION
## Summary
- pass execution settings through `KernelArguments` when invoking Semantic Kernel
- import `KernelArguments` to support new invocation API

## Testing
- `bazel test //python:test_gmail_poller` *(fails: certificate_unknown PKIX path building failed)*
- `bazel run //python:chat_gmail_agent` *(fails: certificate_unknown PKIX path building failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb49d9ba688325a7a6ab7f3bd9800d