### PR TITLE
Fix OpenAI tool_choice error in chat agent

### DIFF
--- a/python/chat_gmail_agent.py
+++ b/python/chat_gmail_agent.py
@@ -42,7 +42,10 @@ async def chat_loop(kernel: sk.Kernel) -> None:
             break
         # Forward user message through the kernel so the model can decide to call functions.
         try:
-            settings = OpenAIChatPromptExecutionSettings(tool_choice="auto")
+            # "tool_choice" requires a tools list in the OpenAI request. We don't
+            # provide one here, so use the legacy "function_call" option instead
+            # to let the model call kernel functions automatically when needed.
+            settings = OpenAIChatPromptExecutionSettings(function_call="auto")
             result = await kernel.invoke(
                 plugin_name="chat",
                 function_name="chat",


### PR DESCRIPTION
## Summary
- switch chat Gmail agent to use `function_call="auto"` instead of `tool_choice`
- add comments explaining the new setting

## Testing
- `bazel test //python:test_gmail_poller` *(fails: certificate_unknown PKIX path building failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4c4cd99c83258cbe11c1e9f6660f