### PR TITLE
Enable Gmail polling via OpenAI tool calling

### DIFF
--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -36,6 +36,7 @@ py_library(
         requirement("google-api-python-client"),
         requirement("google-auth"),
         requirement("google-auth-oauthlib"),
+        requirement("semantic-kernel"),
     ],
     visibility = ["//visibility:public"],
 )
@@ -57,7 +58,7 @@ py_binary(
     main = "chat_gmail_agent.py",
     deps = [
         ":gmail_poller",
-        requirement("semantic-kernel"),
+        requirement("openai"),
     ],
     data = [":gmail_credentials"],
 )


### PR DESCRIPTION
## Summary
- expose Gmail polling to OpenAI via a `gmail_poll` tool and execute calls in the chat loop
- declare missing `semantic-kernel` dependency for `gmail_poller` and depend on `openai` in chat agent

## Testing
- `bazel test //python:gmail_poller_test` *(fails: certificate_unknown PKIX path building failed)*
- `bazel run //python:chat_gmail_agent` *(fails: certificate_unknown PKIX path building failed)*

------
https://chatgpt.com/codex/tasks/task_e_68bb4c4cd99c83258cbe11c1e9f6660f