### PR TITLE
Add cancellable Gmail polling agent with interval control

### DIFF
--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -47,10 +47,17 @@ py_binary(
     main = "local_py/poll_gmail_agent.py",
     imports = ["."],
     deps = [
-        ":gmail_poller",
-        requirement("semantic-kernel"),
+        ":gmail_polling_agent",
     ],
     data = [":gmail_credentials"],
+)
+
+py_library(
+    name = "gmail_polling_agent",
+    srcs = ["local_py/gmail_polling_agent.py"],
+    imports = ["."],
+    deps = [":gmail_poller"],
+    visibility = ["//visibility:public"],
 )
 
 py_library(
@@ -97,6 +104,12 @@ py_test(
     name = "chat_gmail_agent_test",
     srcs = ["test_chat_gmail_agent.py"],
     deps = [":chat_gmail_agent_lib"],
+)
+
+py_test(
+    name = "gmail_polling_agent_test",
+    srcs = ["test_gmail_polling_agent.py"],
+    deps = [":gmail_polling_agent"],
 )
 
 test_suite(

--- a/python/local_py/gmail_polling_agent.py
+++ b/python/local_py/gmail_polling_agent.py
@@ -1,0 +1,37 @@
+import asyncio
+import logging
+from typing import Optional
+
+from .gmail_poller import GmailPoller
+
+
+class GmailPollingAgent:
+    """Continuously poll Gmail for new messages."""
+
+    def __init__(
+        self,
+        poller: GmailPoller,
+        *,
+        sender: Optional[str] = None,
+        interval: int = 60,
+    ) -> None:
+        self.poller = poller
+        self.sender = sender
+        self.interval = interval
+
+    async def run(self, interval: Optional[int] = None) -> None:
+        """Start polling until cancelled.
+
+        Args:
+            interval: Polling interval in seconds. Defaults to the value
+                provided at construction.
+        """
+        delay = interval if interval is not None else self.interval
+        try:
+            while True:
+                for email in self.poller.poll(sender=self.sender):
+                    logging.info("New email %s: %s", email.id, email.snippet)
+                await asyncio.sleep(delay)
+        except asyncio.CancelledError:
+            logging.info("Polling cancelled")
+            raise

--- a/python/local_py/poll_gmail_agent.py
+++ b/python/local_py/poll_gmail_agent.py
@@ -1,33 +1,27 @@
+import argparse
 import asyncio
 import logging
 import os
 
-import semantic_kernel as sk
-
 from .gmail_poller import GmailPoller
+from .gmail_polling_agent import GmailPollingAgent
 
 
-async def main() -> None:
+async def main(interval: int) -> None:
     """Poll Gmail for new messages and log them."""
     logging.basicConfig(level=logging.INFO)
 
-    kernel = sk.Kernel()
     poller = GmailPoller()
-
-    # Register a skill/function that calls `GmailPoller.poll`.
-    kernel.add_function(
-        plugin_name="gmail", function=poller.poll, function_name="poll"
+    agent = GmailPollingAgent(
+        poller,
+        sender=os.environ.get("GMAIL_SENDER"),
+        interval=interval,
     )
-
-    sender = os.environ.get("GMAIL_SENDER", "")
-    while True:
-        result = await kernel.invoke(
-            function_name="poll", plugin_name="gmail", sender=sender
-        )
-        for email in result.value if result else []:
-            logging.info("New email %s: %s", email.id, email.snippet)
-        await asyncio.sleep(60)
+    await agent.run()
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    parser = argparse.ArgumentParser(description="Poll Gmail for new messages")
+    parser.add_argument("--interval", type=int, default=60, help="Polling interval in seconds")
+    args = parser.parse_args()
+    asyncio.run(main(args.interval))

--- a/python/test_gmail_polling_agent.py
+++ b/python/test_gmail_polling_agent.py
@@ -1,0 +1,30 @@
+import asyncio
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from local_py.gmail_polling_agent import GmailPollingAgent
+
+
+class GmailPollingAgentTest(IsolatedAsyncioTestCase):
+    async def test_run_polls_until_cancelled(self) -> None:
+        poller = MagicMock()
+        poller.poll.return_value = []
+
+        agent = GmailPollingAgent(poller)
+        task = asyncio.create_task(agent.run(interval=0))
+        await asyncio.sleep(0.05)
+        task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await task
+        self.assertGreaterEqual(poller.poll.call_count, 1)
+
+    async def test_run_uses_provided_interval(self) -> None:
+        poller = MagicMock()
+        poller.poll.return_value = []
+
+        agent = GmailPollingAgent(poller, interval=10)
+        sleep_mock = AsyncMock(side_effect=asyncio.CancelledError())
+        with patch("local_py.gmail_polling_agent.asyncio.sleep", sleep_mock):
+            with self.assertRaises(asyncio.CancelledError):
+                await agent.run(interval=2)
+        sleep_mock.assert_awaited_with(2)


### PR DESCRIPTION
## Summary
- introduce `GmailPollingAgent` with cancellable `run` loop
- expose polling interval via constructor and CLI flag
- cover polling behavior with new unit tests

## Testing
- `bazelisk test //python:gmail_polling_agent_test` *(fails: Error accessing registry https://bcr.bazel.build/: certificate_unknown)*
- `PYTHONPATH=python python -m unittest python/test_gmail_polling_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_68bb5818411c83259df1120094c253fa