### PR TITLE
Add contribution and style guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,3 +8,8 @@ development should be stored in `.env` (ignored by Git) and loaded with
 `source scripts/export_env.sh`.
 
 All Bazel commands must be executed through Bazelisk to honor `.bazelversion`.
+
+- Python code must follow PEP 8, include type hints, and provide docstrings for modules, classes, and functions.
+- Modules and packages use `snake_case` names under `python/` and should preserve the existing package layout.
+- Favor idiomatic Python with clear object-oriented design and principles.
+- Every new feature requires unit tests; run `bazel test //...` and ensure tests pass before committing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+## Python style
+
+- Follow [PEP 8](https://peps.python.org/pep-0008/).
+- Include type hints for public interfaces and new code.
+- Add docstrings for modules, classes, and functions describing their intent.
+
+## Package layout
+
+- All Python code lives under the `python/` directory.
+- Package and module names use `snake_case`.
+- Preserve the existing package structure from the refactor and group related code together.
+
+## Testing
+
+- Provide unit tests for every new feature or bug fix.
+- Run `bazel test //...` and ensure all tests pass before submitting changes.
+
+## Design
+
+- Write idiomatic Python and favor clear object-oriented programming.
+- Apply sound object-oriented design principles to keep modules focused and maintainable.

--- a/README.md
+++ b/README.md
@@ -125,3 +125,7 @@ export OPENAI_API_BASE=http://localhost:1234/v1
 ```
 
 Replace the base URL with your LLM server's address.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for coding standards, package layout, and testing requirements.


### PR DESCRIPTION
## Summary
- add CONTRIBUTING guide covering style, layout, testing, and design
- document style and testing requirements in AGENTS instructions
- link README to contribution guidelines

## Testing
- `bazel test //...` *(fails: certificate_unknown)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5c8235448325a336713ddebaabba