### PR TITLE
Add setup_venv smoke test and register Bazel targets

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,5 +5,8 @@ alias(
 
 test_suite(
     name = "tests",
-    tests = ["//python:tests"],
+    tests = [
+        "//python:tests",
+        "//python:setup_venv_test",
+    ],
 )

--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -112,6 +112,12 @@ py_test(
     deps = [":gmail_polling_agent"],
 )
 
+py_test(
+    name = "setup_venv_test",
+    srcs = ["test_setup_venv.py"],
+    deps = [":setup_venv"],
+)
+
 test_suite(
     name = "tests",
 )

--- a/python/test_chat_gmail_agent.py
+++ b/python/test_chat_gmail_agent.py
@@ -1,3 +1,5 @@
+"""Tests for :mod:`chat_gmail_agent` using mocked services."""
+
 import json
 from types import SimpleNamespace
 from unittest import TestCase
@@ -8,7 +10,10 @@ from local_py.gmail_poller import Email
 
 
 class ChatGmailAgentTest(TestCase):
+    """Verify chat agent interactions with the Gmail poller."""
+
     def test_run_polls_and_prints_reply(self) -> None:
+        """Poll Gmail and print the agent's reply using mocks."""
         poller = MagicMock()
         poller.poll.return_value = [Email(id="1", snippet="snippet 1")]
 

--- a/python/test_gmail_polling_agent.py
+++ b/python/test_gmail_polling_agent.py
@@ -1,3 +1,5 @@
+"""Tests for the asynchronous Gmail polling agent using mocks."""
+
 import asyncio
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -6,7 +8,10 @@ from local_py.gmail_polling_agent import GmailPollingAgent
 
 
 class GmailPollingAgentTest(IsolatedAsyncioTestCase):
+    """Verify repeated polling behavior and interval handling."""
+
     async def test_run_polls_until_cancelled(self) -> None:
+        """Poll until cancellation to ensure repeated execution."""
         poller = MagicMock()
         poller.poll.return_value = []
 
@@ -19,6 +24,7 @@ class GmailPollingAgentTest(IsolatedAsyncioTestCase):
         self.assertGreaterEqual(poller.poll.call_count, 1)
 
     async def test_run_uses_provided_interval(self) -> None:
+        """Override default interval when provided at run time."""
         poller = MagicMock()
         poller.poll.return_value = []
 

--- a/python/test_setup_venv.py
+++ b/python/test_setup_venv.py
@@ -1,0 +1,49 @@
+"""Smoke tests for the ``setup_venv`` script."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import sys
+import tempfile
+from unittest import TestCase
+from unittest.mock import call, patch
+
+import setup_venv
+
+
+class SetupVenvSmokeTest(TestCase):
+    """Verify virtual environment creation and dependency installation."""
+
+    def test_main_creates_and_installs(self) -> None:
+        """Ensure main invokes commands to create venv and install deps."""
+        with tempfile.TemporaryDirectory() as tmpdir, patch(
+            "setup_venv.run"
+        ) as run_mock, patch.dict(os.environ, {"BUILD_WORKING_DIRECTORY": tmpdir}):
+            setup_venv.main([])
+
+            venv_dir = pathlib.Path(tmpdir) / ".venv"
+            requirements = pathlib.Path(setup_venv.__file__).with_name(
+                "requirements.txt"
+            )
+            run_mock.assert_has_calls(
+                [
+                    call(
+                        [sys.executable, "-m", "venv", str(venv_dir)],
+                        check=True,
+                        text=True,
+                    ),
+                    call(
+                        [
+                            str(setup_venv._venv_python(venv_dir)),
+                            "-m",
+                            "pip",
+                            "install",
+                            "-r",
+                            str(requirements),
+                        ],
+                        check=True,
+                        text=True,
+                    ),
+                ]
+            )


### PR DESCRIPTION
## Summary
- document existing agent tests with module docstrings and mocks
- add smoke test for `setup_venv.py`
- register new test targets in Bazel build files

## Testing
- `bazel test //...` *(fails: PKIX path building failed: unable to find valid certification path to requested target)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5fb1168c83259b2b0aef18b95aa4