### PR TITLE
Handle Gmail poller network timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,11 +138,11 @@ Replace the base URL with your LLM server's address.
 
 ## Testing
 
-Run pre-commit hooks and the full test suite:
+Run pre-commit hooks and the Python test suite:
 
 ```bash
 pre-commit run --all-files
-bazel test //...
+bazel test //python:tests
 ```
 
 ## Contributing

--- a/python/local_py/gmail_poller.py
+++ b/python/local_py/gmail_poller.py
@@ -1,15 +1,19 @@
 """Utilities for polling Gmail for new messages."""
+
 from __future__ import annotations
 
+import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, List, Optional
 
+import httplib2
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
+from google_auth_httplib2 import AuthorizedHttp
 from semantic_kernel.functions import kernel_function
 
 TOKEN_PATH = Path(os.environ.get("GMAIL_TOKEN_PATH", "token.json"))
@@ -41,6 +45,7 @@ class GmailPoller:
         token_path: Path | str = TOKEN_PATH,
         credentials_path: Path | str = CREDENTIALS_PATH,
         service: Any | None = None,
+        timeout: float = 10.0,
     ) -> None:
         """Create a new :class:`GmailPoller`.
 
@@ -51,14 +56,18 @@ class GmailPoller:
                 :data:`CREDENTIALS_PATH`.
             service: Pre-authorized Gmail API service. If provided, authorization
                 is skipped.
+            timeout: Timeout in seconds for Gmail API requests.
         """
 
         self.token_path = Path(token_path)
         self.credentials_path = Path(credentials_path)
-        self.service: Any = service or self._authorize(self.token_path, self.credentials_path)
+        self.timeout = timeout
+        self.service: Any = service or self._authorize(
+            self.token_path, self.credentials_path, timeout
+        )
 
     @staticmethod
-    def _authorize(token_path: Path, credentials_path: Path) -> Any:
+    def _authorize(token_path: Path, credentials_path: Path, timeout: float) -> Any:
         """Return an authorized Gmail API service."""
         creds: Credentials | None = None
         if token_path.exists():
@@ -72,9 +81,12 @@ class GmailPoller:
                 )
                 creds = flow.run_local_server(port=0)
             token_path.write_text(creds.to_json())
-        return build("gmail", "v1", credentials=creds)
+        authed_http = AuthorizedHttp(creds, http=httplib2.Http(timeout=timeout))
+        return build("gmail", "v1", http=authed_http)
 
-    @kernel_function(description="Poll Gmail for unread messages, optionally filtered by sender.")
+    @kernel_function(
+        description="Poll Gmail for unread messages, optionally filtered by sender."
+    )
     def poll(self, sender: Optional[str] = None) -> List[Email]:
         """Return unread messages.
 
@@ -82,18 +94,23 @@ class GmailPoller:
         Messages are marked as read so they are not returned again.
         """
         query = f"from:{sender} is:unread" if sender else "is:unread"
-        result = (
-            self.service.users()
-            .messages()
-            .list(userId="me", q=query)
-            .execute()
-        )
+        try:
+            result = (
+                self.service.users().messages().list(userId="me", q=query).execute()
+            )
+        except Exception as exc:  # pragma: no cover - network failure
+            logging.warning("Failed to poll Gmail: %s", exc)
+            return []
         messages = result.get("messages", [])
         emails: List[Email] = []
         for msg in messages:
-            full = self.service.users().messages().get(userId="me", id=msg["id"]).execute()
+            full = (
+                self.service.users().messages().get(userId="me", id=msg["id"]).execute()
+            )
             emails.append(Email(id=full["id"], snippet=full.get("snippet", "")))
             self.service.users().messages().modify(
-                userId="me", id=full["id"], body={"removeLabelIds": ["UNREAD"]}
+                userId="me",
+                id=full["id"],
+                body={"removeLabelIds": ["UNREAD"]},  # pragma: no cover - network
             ).execute()
         return emails

--- a/python/test_gmail_poller.py
+++ b/python/test_gmail_poller.py
@@ -54,6 +54,15 @@ class GmailPollerTest(TestCase):
             userId="me", id="2", body={"removeLabelIds": ["UNREAD"]}
         )
 
+    def test_poll_handles_errors(self) -> None:
+        poller = GmailPoller(service=self.service)
+        self.messages.list.return_value.execute.side_effect = OSError("boom")
+
+        emails = poller.poll("sender@example.com")
+
+        self.assertEqual([], emails)
+        self.messages.get.assert_not_called()
+
     def test_poll_kernel_function(self) -> None:
         poller = GmailPoller(service=self.service)
         kernel = sk.Kernel()


### PR DESCRIPTION
## Summary
- avoid hanging Gmail requests by injecting an AuthorizedHttp client with a timeout
- handle Gmail polling failures gracefully and document testing command

## Testing
- `pre-commit run --all-files` *(fails: Failed to build installable wheels for some pyproject.toml based projects: shellcheck_py)*
- `bazel test //python:tests` *(fails: Error accessing registry https://bcr.bazel.build/)*
- `PYTHONPATH=python python -m unittest python/test_gmail_poller.py`

------
https://chatgpt.com/codex/tasks/task_e_68bb6f31610483258d870d4109e61344