### PR TITLE
Fix Bazel test target for setup_venv

### DIFF
--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -116,6 +116,7 @@ py_test(
 py_test(
     name = "setup_venv_test",
     srcs = ["test_setup_venv.py"],
+    main = "test_setup_venv.py",
     deps = [":setup_venv"],
 )
 


### PR DESCRIPTION
## Summary
- declare the actual test file as the entry point for `setup_venv_test`

## Testing
- `bazel test //python:tests` *(fails: Error accessing registry https://bcr.bazel.build/)*
- `pre-commit run --all-files` *(fails: Failed building wheel for shellcheck_py)*

------
https://chatgpt.com/codex/tasks/task_e_68bb731698448325a01064473e4d88c4