### PR TITLE
Fix Bazel test target for setup_venv

### DIFF
--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -98,24 +98,28 @@ py_binary(
 py_test(
     name = "gmail_poller_test",
     srcs = ["test_gmail_poller.py"],
+    main = "test_gmail_poller.py",
     deps = [":gmail_poller"],
 )
 
 py_test(
     name = "chat_gmail_agent_test",
     srcs = ["test_chat_gmail_agent.py"],
+    main = "test_chat_gmail_agent.py",
     deps = [":chat_gmail_agent_lib"],
 )
 
 py_test(
     name = "gmail_polling_agent_test",
     srcs = ["test_gmail_polling_agent.py"],
+    main = "test_gmail_polling_agent.py",
     deps = [":gmail_polling_agent"],
 )
 
 py_test(
     name = "setup_venv_test",
     srcs = ["test_setup_venv.py"],
+    main = "test_setup_venv.py",
     deps = [":setup_venv"],
 )
 


### PR DESCRIPTION
## Summary
- declare the actual test file as the entry point for `setup_venv_test`
- specify main test files for `gmail_poller_test`, `chat_gmail_agent_test`, and `gmail_polling_agent_test`

## Testing
- `pre-commit run --all-files` *(fails: Failed to build shellcheck_py wheel)*
- `bazel test //...` *(fails: certificate_unknown fetching registry https://bcr.bazel.build/)*

------
https://chatgpt.com/codex/tasks/task_e_68bb731698448325a01064473e4d88c4