### PR TITLE
refactor: add setup_venv library

### DIFF
--- a/python/BUILD.bazel
+++ b/python/BUILD.bazel
@@ -8,6 +8,13 @@ filegroup(
     srcs = ["credentials.sample.json"],
 )
 
+py_library(
+    name = "setup_venv_lib",
+    srcs = ["setup_venv.py"],
+    imports = ["."],
+    visibility = ["//visibility:public"],
+)
+
 py_binary(
     name = "hello",
     srcs = ["hello.py"],
@@ -23,8 +30,8 @@ py_binary(
 
 py_binary(
     name = "setup_venv",
-    srcs = ["setup_venv.py"],
     main = "setup_venv.py",
+    deps = [":setup_venv_lib"],
     data = ["requirements.txt"],
     visibility = ["//visibility:public"],
 )
@@ -120,7 +127,7 @@ py_test(
     name = "setup_venv_test",
     srcs = ["test_setup_venv.py"],
     main = "test_setup_venv.py",
-    deps = [":setup_venv"],
+    deps = [":setup_venv_lib"],
 )
 
 test_suite(


### PR DESCRIPTION
## Summary
- extract setup_venv.py into reusable py_library
- update setup_venv binary and test to depend on the new library

## Testing
- `SKIP=shellcheck pre-commit run --all-files`
- `bazel test //python:setup_venv_test` *(fails: Error accessing registry https://bcr.bazel.build/: certificate_unknown)*

------
https://chatgpt.com/codex/tasks/task_e_68bb86d82d748325b2a2738325b909d9