### PR TITLE
feat: add gmail poll status messages

### DIFF
--- a/python/chat_gmail_agent.py
+++ b/python/chat_gmail_agent.py
@@ -86,7 +86,12 @@ class ChatGmailAgent:
             if getattr(message, "tool_calls", None):
                 for call in message.tool_calls:
                     if call.function.name == "gmail_poll":
+                        print_fn("Checking Gmail...")
                         emails = self._handle_gmail_poll(call.function.arguments)
+                        count = len(emails)
+                        print_fn(
+                            f"Found {count} unread email{'s' if count != 1 else ''}."
+                        )
                         content = json.dumps([asdict(email) for email in emails])
                         messages.append(
                             {

--- a/python/tests/test_chat_gmail_agent.py
+++ b/python/tests/test_chat_gmail_agent.py
@@ -47,7 +47,15 @@ class ChatGmailAgentTest(TestCase):
         agent.run(input_fn=fake_input, print_fn=fake_print)
 
         poller.poll.assert_called_once_with(sender=None)
-        self.assertIn("All done", outputs[-1])
+        self.assertEqual(
+            [
+                "Type 'exit' to quit.",
+                "Checking Gmail...",
+                "Found 1 unread email.",
+                "All done",
+            ],
+            outputs,
+        )
 
         tool_message = client.chat.completions.create.call_args_list[1].kwargs[
             "messages"


### PR DESCRIPTION
## Summary
- log when the agent checks Gmail and report unread email count
- expand unit test to cover new status messages

## Testing
- `pre-commit run --all-files` *(fails: Failed to build installable wheels for shellcheck_py: certificate verify failed)*
- `bazel test //...` *(fails: PKIX path building failed: unable to find valid certification path)*

------
https://chatgpt.com/codex/tasks/task_e_68bb952855708325aff549c7bcb003e0